### PR TITLE
Add Confluent Cloud promotional banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Try Confluent Cloud - The Data Streaming Platform](https://images.ctfassets.net/8vofjvai1hpv/10bgcSfn5MzmvS4nNqr94J/af43dd2336e3f9e0c0ca4feef4398f6f/confluent-banner-v2.svg)](https://confluent.cloud/signup?utm_source=github&utm_medium=banner&utm_campaign=oss-repos&utm_term=confluent-cloud-flink-workshop)
+
 # Flink Confluent Cloud for Apache Flink Online Store Workshop
 
 This repository sets up the necessary infrastructure for the Confluent Cloud: Getting Started with Apache Flink workshop. It simulates data for a third-party reseller offering products from major vendors like Amazon and Walmart.


### PR DESCRIPTION
## Summary
- Adds a promotional banner for Confluent Cloud at the top of the README
- Banner includes a call-to-action for $400 free credits
- Uses centrally managed SVG from Contentful CMS

## Changes
- Added banner image with link to Confluent Cloud signup
- Includes UTM parameters for tracking (utm_term=confluent-cloud-flink-workshop)

## Visual Preview
The banner displays:
- "Confluent Cloud" branding
- "Start streaming in minutes" tagline  
- Process flow: Stream → Connect → Process → Govern
- "$400 Free Credits" CTA button

## Testing
- [x] Banner renders correctly in GitHub markdown
- [x] Link directs to Confluent Cloud signup with proper UTM parameters
- [x] Image is served from Contentful CMS

## Related
This is part of a broader growth initiative to add consistent banners across Confluent's open source repositories, promoting Confluent's value proposition.